### PR TITLE
(After #20) Add block and header encoding and unit tests

### DIFF
--- a/runtime/assembly/__tests__/block.spec.ts
+++ b/runtime/assembly/__tests__/block.spec.ts
@@ -1,12 +1,13 @@
 import { Block } from "../models";
 import { MockBuilder } from "./mock-builder";
+import { Utils } from "../utils";
 
 describe("Block", () => {
 
   it("should instanciate empty block from SCALE encoded Byte array", () => {
     const mock = MockBuilder.getEmptyBlockMock();
     const block = Block.fromU8Array(mock.bytes);
-    assert(block.result == mock.expectedObject, "empty block was not instanciated properly");
+    assert(block.result == mock.instance, "empty block was not instanciated properly");
 
     __retain(changetype<usize>(mock));
     __retain(changetype<usize>(block))
@@ -16,10 +17,10 @@ describe("Block", () => {
     const mock = MockBuilder.getBlockWithExtrinsics();
     const block = Block.fromU8Array(mock.bytes);
     assert(block.result.body.length == 2, "Extrinciscs were not instanciated properly");
-    assert(block.result == mock.expectedObject, "block with extrinsic was not instanciated properly");
-    assert(block.result.header == mock.expectedObject.header, "header part of the block object was not instanciated properly");
-    assert(block.result.body[0] == mock.expectedObject.body[0], "Extrinsic was not instanciated properly");
-    assert(block.result.body[1] == mock.expectedObject.body[1], "Extrinsic was not instanciated properly");
+    assert(block.result == mock.instance, "block with extrinsic was not instanciated properly");
+    assert(block.result.header == mock.instance.header, "header part of the block object was not instanciated properly");
+    assert(block.result.body[0] == mock.instance.body[0], "Extrinsic was not instanciated properly");
+    assert(block.result.body[1] == mock.instance.body[1], "Extrinsic was not instanciated properly");
 
     __retain(changetype<usize>(mock));
     __retain(changetype<usize>(block))
@@ -29,16 +30,23 @@ describe("Block", () => {
     const mock = MockBuilder.getBlockWithExtrinsicsAndDigests();
     const block = Block.fromU8Array(mock.bytes);
 
-    assert(block.result == mock.expectedObject, "block with extrinsic and digests was not instanciated properly");
+    assert(block.result == mock.instance, "block with extrinsic and digests was not instanciated properly");
 
     __retain(changetype<usize>(mock));
     __retain(changetype<usize>(block))
   });
 
-  // TODO will fix in another PR
-  // it("should encode block without digests correctly", () => {
-  // });
+  it("should encode block without digests correctly", () => {
+    const block = MockBuilder.getBlockWithExtrinsics();
+    assert(Utils.areArraysEqual(block.instance.toU8a(), block.bytes), "Block without digests was not encoded successfully");
 
-  // TODO Should encode block with digests correctly
-  // TODO will fix in another PR
+    __retain(changetype<usize>(block));
+  });
+
+  it("should encode block with digests correctly", () => {
+    const block = MockBuilder.getBlockWithExtrinsicsAndDigests();
+    assert(Utils.areArraysEqual(block.instance.toU8a(), block.bytes), "Block with digests was not encoded successfully");
+
+    __retain(changetype<usize>(block));
+  });
 });

--- a/runtime/assembly/__tests__/digest-items.spec.ts
+++ b/runtime/assembly/__tests__/digest-items.spec.ts
@@ -9,7 +9,7 @@ describe("Digest Item", () => {
     it("should instanciate Other Digest Item", () => {
         const mock = MockBuilder.getOtherDigestItemMock();
         const digestItem = DigestItem.fromU8Array(mock.bytes);
-        assert(digestItem.result == mock.expectedObject, "Other Digest Item was not instanciated properly");
+        assert(digestItem.result == mock.instance, "Other Digest Item was not instanciated properly");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(digestItem));
@@ -25,7 +25,7 @@ describe("Digest Item", () => {
     it("should instanciate ChangeTrieRoot Digest Item", () => {
         const mock = MockBuilder.getChangeTrieRootDigestItemMock();
         const digestItem = DigestItem.fromU8Array(mock.bytes);
-        assert(digestItem.result == mock.expectedObject, "ChangeTrieRoot Digest Item was not instanciated properly");
+        assert(digestItem.result == mock.instance, "ChangeTrieRoot Digest Item was not instanciated properly");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(digestItem));
@@ -41,7 +41,7 @@ describe("Digest Item", () => {
     it("Should instanciate Consensus Digest Item", () => {
         const mock = MockBuilder.getConsensusDigestItemMock();
         const digestItem = DigestItem.fromU8Array(mock.bytes);
-        assert(digestItem.result == mock.expectedObject, "Consensus Digest Item was not instanciated properly");
+        assert(digestItem.result == mock.instance, "Consensus Digest Item was not instanciated properly");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(digestItem));
@@ -64,7 +64,7 @@ describe("Digest Item", () => {
     it("Should instanciate Seal Digest Item", () => {
         const mock = MockBuilder.getSealDigestItemMock();
         const digestItem = DigestItem.fromU8Array(mock.bytes);
-        assert(digestItem.result == mock.expectedObject, "Seal Digest Item was not instanciated properly");
+        assert(digestItem.result == mock.instance, "Seal Digest Item was not instanciated properly");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(digestItem));
@@ -87,7 +87,7 @@ describe("Digest Item", () => {
     it("Should instanciate PreRuntime Digest Item", () => {
         const mock = MockBuilder.getPreRuntimeDigestItemMock();
         const digestItem = DigestItem.fromU8Array(mock.bytes);
-        assert(digestItem.result == mock.expectedObject, "PreRuntime Digest Item was not instanciated properly");
+        assert(digestItem.result == mock.instance, "PreRuntime Digest Item was not instanciated properly");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(digestItem));

--- a/runtime/assembly/__tests__/extrinsic.spec.ts
+++ b/runtime/assembly/__tests__/extrinsic.spec.ts
@@ -5,7 +5,7 @@ describe("Extrinsic", () => {
     it("should instanciate default extrinsic from the SCALE encoded byte array", () => {
         const mock = MockBuilder.getDefaultExtrinsic();
         const ext = Extrinsic.fromU8Array(mock.bytes);
-        assert(mock.expectedObject == ext.result, "The result Extrinsic is not the same as the expected");
+        assert(mock.instance == ext.result, "The result Extrinsic is not the same as the expected");
 
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(ext));

--- a/runtime/assembly/__tests__/header.spec.ts
+++ b/runtime/assembly/__tests__/header.spec.ts
@@ -1,5 +1,5 @@
 import { Header } from '../models/header';
-import { MockBuilder, MockHelper } from './mock-builder';
+import { MockBuilder } from './mock-builder';
 import { Hash, CompactInt } from 'as-scale-codec';
 import { Option, DigestItem } from '../models';
 import { Utils } from '../utils';
@@ -11,7 +11,7 @@ describe("Header", () => {
     const mock = MockBuilder.getHeaderWithoutDigestMock();
     const decodedData = Header.fromU8Array(mock.bytes);
 
-    assert(decodedData.result == mock.expectedObject, "header was not instanciated properly");
+    assert(decodedData.result == mock.instance, "header was not instanciated properly");
 
     __retain(changetype<usize>(mock));
     __retain(changetype<usize>(decodedData))
@@ -21,7 +21,7 @@ describe("Header", () => {
     const mock = MockBuilder.getHeaderWithDigestsMock();
     const decodedData = Header.fromU8Array(mock.bytes);
 
-    assert(decodedData.result == mock.expectedObject, "header with digests was not instanciated properly");
+    assert(decodedData.result == mock.instance, "header with digests was not instanciated properly");
 
     __retain(changetype<usize>(mock));
     __retain(changetype<usize>(decodedData))
@@ -39,17 +39,16 @@ describe("Header", () => {
   });
 
   it("should encode header without digests correctly", () => {
-    const header = MockHelper.getHeaderInstanceWithoutDigest();
-    assert(Utils.areArraysEqual(header.toU8a(), MockConstants.HEADER_WITHOUT_DIGEST), "Header without digests was not encoded successfully");
+    const header = MockBuilder.getHeaderWithoutDigestMock()
+    assert(Utils.areArraysEqual(header.instance.toU8a(), header.bytes), "Header without digests was not encoded successfully");
     __retain(changetype<usize>(header));
   });
 
-  // TODO fix in another PR
-  // it("should encode header with digests correctly", () => {
-  //   const header = MockHelper.getHeaderInstanceWithDigests();
+  it("should encode header with digests correctly", () => {
+    const header = MockBuilder.getHeaderWithDigestsMock();
     
-  //   assert(Utils.areArraysEqual(header.toU8a(), MockConstants.HEADER_WITH_DIGEST), "Header without digests was not encoded successfully");
-  //   __retain(changetype<usize>(header));
-  // });
+    assert(Utils.areArraysEqual(header.instance.toU8a(), header.bytes), "Header without digests was not encoded successfully");
+    __retain(changetype<usize>(header));
+  });
 
 });

--- a/runtime/assembly/__tests__/inherent.spec.ts
+++ b/runtime/assembly/__tests__/inherent.spec.ts
@@ -7,7 +7,7 @@ describe("Inherent", () => {
         const mock: MockResult<Inherent> = MockBuilder.getInherentMock();
         const decodedData = Inherent.fromU8Array(mock.bytes);
 
-        expect(decodedData == mock.expectedObject).toBeTruthy();
+        expect(decodedData == mock.instance).toBeTruthy();
         __retain(changetype<usize>(mock));
         __retain(changetype<usize>(decodedData));
     })

--- a/runtime/assembly/__tests__/mock-builder.ts
+++ b/runtime/assembly/__tests__/mock-builder.ts
@@ -14,7 +14,7 @@ export namespace MockBuilder {
      * Returns SCALE Encoded Empty Block mock and instance of that block
      */
     export function getEmptyBlockMock(): MockResult<Block> {
-        const header = MockHelper.getHeaderInstanceWithoutDigest();
+        const header = MockHelper._getHeaderInstanceWithoutDigest();
         const block = new Block(header, []);
         return new MockResult(block, MockConstants.EMPTY_BLOCK);
     }
@@ -23,9 +23,9 @@ export namespace MockBuilder {
      * Returns SCALE Encoded Block with extrinsics mock and instance of that block
      */
     export function getBlockWithExtrinsics(): MockResult<Block> {
-        const header = MockHelper.getHeaderInstanceWithoutDigest();
-        const extrinsic1 = MockHelper.getExtrinsicInstance1();
-        const extrinsic2 = MockHelper.getExtrinsicInstance2();
+        const header = MockHelper._getHeaderInstanceWithoutDigest();
+        const extrinsic1 = MockHelper._getExtrinsicInstance1();
+        const extrinsic2 = MockHelper._getExtrinsicInstance2();
         return new MockResult(new Block(header, [extrinsic1, extrinsic2]), MockConstants.BLOCK_WITH_EXTRINSIC)
     }
 
@@ -33,9 +33,9 @@ export namespace MockBuilder {
      * Returns SCALE Encoded Block with extrinsics and digests mock and instance of that block
      */
     export function getBlockWithExtrinsicsAndDigests(): MockResult<Block> {
-        const header = MockHelper.getHeaderInstanceWithDigests();
-        const extrinsic1 = MockHelper.getExtrinsicInstance1();
-        const extrinsic2 = MockHelper.getExtrinsicInstance2();
+        const header = MockHelper._getHeaderInstanceWithDigests();
+        const extrinsic1 = MockHelper._getExtrinsicInstance1();
+        const extrinsic2 = MockHelper._getExtrinsicInstance2();
         return new MockResult(new Block(header, [extrinsic1, extrinsic2]), MockConstants.BLOCK_WITH_EXTRINSIC_AND_DIGESTS)
     }
 
@@ -43,28 +43,28 @@ export namespace MockBuilder {
      * Returns SCALE Encoded Header Mock and Instance of that Header
      */
     export function getHeaderWithoutDigestMock(): MockResult<Header> {
-        return new MockResult(MockHelper.getHeaderInstanceWithoutDigest(), MockConstants.HEADER_WITHOUT_DIGEST);
+        return new MockResult(MockHelper._getHeaderInstanceWithoutDigest(), MockConstants.HEADER_WITHOUT_DIGEST);
     }
 
     /**
      * Returns SCALE Encoded Header with Digests Mock and Instance of that Header
      */
     export function getHeaderWithDigestsMock(): MockResult<Header> {
-        return new MockResult(MockHelper.getHeaderInstanceWithDigests(), MockConstants.HEADER_WITH_DIGEST);
+        return new MockResult(MockHelper._getHeaderInstanceWithDigests(), MockConstants.HEADER_WITH_DIGEST);
     }
 
     /**
      * Returns SCALE encoded Inherent Mock and Instance of that Mock
      */
      export function getInherentMock(): MockResult<Inherent> {
-         return new MockResult(MockHelper.getEmptyInherentInstance(), MockConstants.DEFAULT_INHERENT);
+         return new MockResult(MockHelper._getEmptyInherentInstance(), MockConstants.DEFAULT_INHERENT);
      }
 
     /**
      * Returns SCALE encoded extrinsic mock and Instance of that mock
      */
     export function getDefaultExtrinsic(): MockResult<Extrinsic> {
-        return new MockResult(MockHelper.getExtrinsicInstance1(), MockConstants.DEFAULT_EXTRINSIC);
+        return new MockResult(MockHelper._getExtrinsicInstance1(), MockConstants.DEFAULT_EXTRINSIC);
     }
 
     /**
@@ -124,12 +124,12 @@ export namespace MockBuilder {
 /**
  * Namesapce containing helper functions for the Mock Builder. Should be used only internally
  */
-export namespace MockHelper {
+namespace MockHelper {
     /**
      * Returns a Header instance with a populated parent hash, block number, stateRoot and extrinsics root.
      * Used Internally in the mock builder
      */
-    export function getHeaderInstanceWithoutDigest(): Header {
+    export function _getHeaderInstanceWithoutDigest(): Header {
         const hash69 = Hash.fromU8a([69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69]);
         const hash255 = Hash.fromU8a([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
         const blockNumber = new CompactInt(1);
@@ -141,16 +141,16 @@ export namespace MockHelper {
      * Returns a Header instance with a populated parent hash, block number, stateRoot, extrinsics root and digests.
      * Used Internally in the mock builder
      */
-    export function getHeaderInstanceWithDigests(): Header {
+    export function _getHeaderInstanceWithDigests(): Header {
         const hash69 = Hash.fromU8a([69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69]);
         const hash255 = Hash.fromU8a([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
         const blockNumber = new CompactInt(1);
 
-        const digest = new Option<DigestItem[]>(MockHelper.getDigests());
+        const digest = new Option<DigestItem[]>(MockHelper._getDigests());
         return new Header(hash69, blockNumber, hash255, hash255, digest);
     }
 
-    export function getEmptyInherentInstance(): Inherent {
+    export function _getEmptyInherentInstance(): Inherent {
         const timestamp: UInt64 = new UInt64(0);
         const babeslot: UInt64 = new UInt64(0);
         const finalnum: CompactInt = new CompactInt(0);
@@ -159,7 +159,7 @@ export namespace MockHelper {
         return new Inherent(timestamp, babeslot, finalnum, headers);
     }
     
-    export function getExtrinsicInstance1(): Extrinsic {
+    export function _getExtrinsicInstance1(): Extrinsic {
         const from = Hash.fromU8a(MockConstants.ALICE_ADDRESS);
         const to  = Hash.fromU8a(MockConstants.BOB_ADDRESS);
         const amount: UInt64 = new UInt64(69);
@@ -169,7 +169,7 @@ export namespace MockHelper {
         return new Extrinsic(from, to, amount, nonce, signature, exhaustResource);
     }
 
-    export function getExtrinsicInstance2(): Extrinsic {
+    export function _getExtrinsicInstance2(): Extrinsic {
         const from = Hash.fromU8a(MockConstants.ALICE_ADDRESS);
         const to = Hash.fromU8a(MockConstants.BOB_ADDRESS);
         const amount: UInt64 = new UInt64(70);
@@ -179,7 +179,7 @@ export namespace MockHelper {
         return new Extrinsic(from, to, amount, nonce, signature, exhaustResource);
     }
 
-    export function getDigests(): DigestItem[] {
+    export function _getDigests(): DigestItem[] {
         const digestsArr = new Array<DigestItem>();
         digestsArr.push(new Other(ByteArray.fromU8a([12, 1, 1, 1])));
         const trieRootValue = Hash.fromU8a([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);

--- a/runtime/assembly/__tests__/mock-result.ts
+++ b/runtime/assembly/__tests__/mock-result.ts
@@ -3,11 +3,11 @@
  */
 export class MockResult<T> {
 
-    public expectedObject: T;
+    public instance: T;
     public bytes: u8[];
 
     constructor(expectedObject: T, bytes: u8[]) {
-        this.expectedObject = expectedObject;
+        this.instance = expectedObject;
         this.bytes = bytes;
     }
 

--- a/runtime/assembly/models/block.ts
+++ b/runtime/assembly/models/block.ts
@@ -1,7 +1,8 @@
-import { Hash, ByteArray, Bytes } from "as-scale-codec";
+import { Hash, ByteArray, Bytes, CompactInt } from "as-scale-codec";
 import { Header, Extrinsic, Option } from ".";
 import { DecodedData } from "../codec/decoded-data";
 import { Utils } from "../utils";
+import { Constants } from "../constants";
 
 /**
  * Class representing a Block into the Substrate Runtime
@@ -44,9 +45,22 @@ export class Block {
         this.justification = new Option<ByteArray>(null);
     }
 
+    /**
+    * SCALE Encodes the Block into u8[]
+    */
     toU8a(): u8[] {
-        // TODO fix in another PR
-        return [];
+        let encoded = this.header.toU8a();
+        if (this.body.length != 0) {
+            const extrinsicsLength = new CompactInt(this.body.length);
+            encoded = encoded.concat(extrinsicsLength.toU8a());
+            for (let i = 0; i < this.body.length; i++) {
+                encoded = encoded.concat(this.body[i].toU8a());
+            }
+        } else {
+            encoded = encoded.concat(Constants.EMPTY_BYTE_ARRAY);
+        }
+
+        return encoded;
     }
 
     /**

--- a/runtime/assembly/models/header.ts
+++ b/runtime/assembly/models/header.ts
@@ -44,14 +44,12 @@ export class Header {
     /**
     * SCALE Encodes the Header into u8[]
     */
-    // TODO fix in another PR
     toU8a(): u8[] {
         let digest:u8[] = [];
         if (this.digests.isSome()) {
             let digestItemArray = <DigestItem[]>this.digests.unwrap();
             const length = new CompactInt(digestItemArray.length);
-            digest.concat(length.toU8a());
-            digestItemArray = digestItemArray.splice(length.encodedLength());
+            digest = digest.concat(length.toU8a());
             
             for (let i = 0; i < length.value; i++){
                 digest = digest.concat(digestItemArray[i].toU8a());


### PR DESCRIPTION
closes #8 