### PR TITLE
Docker slim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/
 
 # The cache for chain data in container
 .local
+node-template/customSpecRaw.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,45 +10,38 @@ COPY ./node-template/customSpec.json ./runtime/tools/spec-builder/customSpec.jso
 
 WORKDIR /usr/src/runtime
 
-RUN yarn install
-
-RUN yarn run build
-
-RUN mv wasm-code ./tools/spec-builder
+RUN yarn install && yarn run build && mv wasm-code ./tools/spec-builder
 
 WORKDIR /usr/src/runtime/tools/spec-builder
 
-RUN apt-get update -y 
-RUN apt-get install jq -y
-RUN yarn run asbuild && bash cr-custom-spec.sh
-RUN yarn build-spec -f customSpec.json
+RUN apt-get update -y && apt-get install jq -y
+RUN yarn run asbuild && bash cr-custom-spec.sh && yarn build-spec -f customSpec.json
 CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
 
 # Building node and running it with the customSpecRaw.json
 
 FROM rust:1.45 AS node-builder
 
-WORKDIR /usr/src/dummy
+WORKDIR /usr/src/node
 
 COPY ./node-template ./
 
 COPY --from=builder /usr/src/runtime/tools/spec-builder/customSpecRaw.json ./
 
 RUN bash ./scripts/init.sh
-RUN apt-get update -y 
-RUN apt-get -y install clang
-RUN apt-get -y install gcc
-RUN apt-get -y install cmake
+RUN apt-get update -y &&\
+    apt-get -y install clang &&\
+    apt-get -y install gcc &&\ 
+    apt-get -y install cmake
 
 RUN cargo build --release
-
-EXPOSE 9933/tcp
 
 CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
 
 FROM ubuntu:latest
-WORKDIR /usr/src/node
-COPY --from=node-builder /usr/src/dummy/target/release/node-template ./node-template
-COPY --from=node-builder /usr/src/dummy/customSpecRaw.json ./customSpecRaw.json
-RUN ls
+WORKDIR /usr/src/app
+COPY --from=node-builder /usr/src/node/target/release/node-template ./node-template
+COPY --from=node-builder /usr/src/node/customSpecRaw.json ./customSpecRaw.json
+EXPOSE 9933
+EXPOSE 9944/tcp
 ENTRYPOINT ["./node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ RUN cargo build --release
 
 EXPOSE 9933/tcp
 
-ENTRYPOINT ["./target/release/node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933"]
-
+CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
 
 FROM ubuntu:latest
 WORKDIR /usr/src/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,11 @@ RUN cargo build --release
 EXPOSE 9933/tcp
 
 ENTRYPOINT ["./target/release/node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933"]
+
+
+FROM ubuntu:latest
+WORKDIR /usr/src/node
+COPY --from=node-builder /usr/src/dummy/target/release/node-template ./node-template
+COPY --from=node-builder /usr/src/dummy/customSpecRaw.json ./customSpecRaw.json
+RUN ls
+ENTRYPOINT ["./node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ WORKDIR /usr/src/runtime/tools/spec-builder
 
 RUN apt-get update -y && apt-get install jq -y
 RUN yarn run asbuild && bash cr-custom-spec.sh && yarn build-spec -f customSpec.json
-CMD ["ls"]
 
 # Building node and running it with the customSpecRaw.json
 
@@ -34,13 +33,9 @@ RUN apt-get update -y &&\
 
 RUN cargo build --release
 
-CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
-
 FROM ubuntu:18.04
 WORKDIR /usr/src/app
 COPY --from=node-builder /usr/src/node/target/release/node-template ./node-template
 COPY --from=node-builder /usr/src/node/customSpecRaw.json ./customSpecRaw.json
-EXPOSE 9933
-EXPOSE 9944/tcp
-EXPOSE 30333
+EXPOSE 9933 9944/tcp 30333
 ENTRYPOINT ["./node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933", "--ws-port", "9944", "--port", "30333"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /usr/src/runtime/tools/spec-builder
 
 RUN apt-get update -y && apt-get install jq -y
 RUN yarn run asbuild && bash cr-custom-spec.sh && yarn build-spec -f customSpec.json
-CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
+CMD ["ls"]
 
 # Building node and running it with the customSpecRaw.json
 
@@ -30,18 +30,17 @@ COPY --from=builder /usr/src/runtime/tools/spec-builder/customSpecRaw.json ./
 
 RUN bash ./scripts/init.sh
 RUN apt-get update -y &&\
-    apt-get -y install clang &&\
-    apt-get -y install gcc &&\ 
-    apt-get -y install cmake
+    apt-get -y install clang gcc cmake
 
 RUN cargo build --release
 
 CMD ["/usr/bin/echo", "succesfully build as-runtime and generated chainspec file"]
 
-FROM ubuntu:latest
+FROM ubuntu:18.04
 WORKDIR /usr/src/app
 COPY --from=node-builder /usr/src/node/target/release/node-template ./node-template
 COPY --from=node-builder /usr/src/node/customSpecRaw.json ./customSpecRaw.json
 EXPOSE 9933
 EXPOSE 9944/tcp
-ENTRYPOINT ["./node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933"]
+EXPOSE 30333
+ENTRYPOINT ["./node-template", "--chain=./customSpecRaw.json", "--rpc-port", "9933", "--ws-port", "9944", "--port", "30333"]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ New `wasm-code` binary file will be generated in the `runtime` folder.
         --chain=./customSpecRaw.json \  
         --port 30333 \     
         --ws-port 9944 \      
+        --rpc-port 9933 \
         --telemetry-url 'ws://telemetry.polkadot.io:1024 0' \  
         --validator \   
         --rpc-methods=Unsafe \  
@@ -168,9 +169,8 @@ docker pull limechain/as-substrate
 Then run the executable:
 
 ```
-docker run -p 9933:9933 --name node-runtime limechain/as-substrate \
-    --port 30333 \
-    --ws-port 9944 \
+docker run -p 9933:9933 -p 9944:9944 -p 30333:30333 --name node-runtime 
+limechain/as-substrate \
     --telemetry-url 'ws://telemetry.polkadot.io:1024 0' \
     --validator \
     --rpc-methods=Unsafe \
@@ -189,9 +189,7 @@ docker build -t substrate/runtime .
 It might take a while for Rust to compile the project (~30-40 minutes). After you built the image, run the node:
 
 ```
-docker run -p 9933:9933 --name node-runtime substrate/runtime \
-    --port 30333 \
-    --ws-port 9944 \
+docker run -p 9933:9933 -p 9944:9944 -p 30333:30333 --name node-runtime substrate/runtime \
     --telemetry-url 'ws://telemetry.polkadot.io:1024 0' \
     --validator \
     --rpc-methods=Unsafe \

--- a/README.md
+++ b/README.md
@@ -156,6 +156,31 @@ New `wasm-code` binary file will be generated in the `runtime` folder.
 
 You should have [Docker](https://docker.io) installed.
 
+### Docker image from Docker hub (option 1)
+
+We have a Docker Hub repository where we host the latest image of the whole project. This is the easiest and fastest way to run the Substrate node with Assemblyscript Runtime.
+
+First, pull the image from the Docker Hub. 
+``` 
+docker pull limechain/as-substrate
+```
+
+Then run the executable:
+
+```
+docker run -p 9933:9933 --name node-runtime limechain/as-substrate \
+    --port 30333 \
+    --ws-port 9944 \
+    --telemetry-url 'ws://telemetry.polkadot.io:1024 0' \
+    --validator \
+    --rpc-methods=Unsafe \
+    --name Node01 \
+    --base-path /tmp/node01 \
+    --execution Wasm
+    --rpc-external
+```
+
+### Build the image (option 2)
 First, build the Docker image:
 
 ```
@@ -171,11 +196,12 @@ docker run -p 9933:9933 --name node-runtime substrate/runtime \
     --validator \
     --rpc-methods=Unsafe \
     --name Node01 \
-    --base-path ./tmp/node01 \
+    --base-path /tmp/node01 \
     --execution Wasm
     --rpc-external
 ```
 And the node should start running and attempting to produce blocks. However, since block construction is not yet implemented, no blocks will be produced. Note that `rpc-external` option is required for accessing the node with RPC calls.
+
 
 ## Test Runtime modules with RPC calls
 


### PR DESCRIPTION
- Optimized Dockerfile to contain only the executable (4GBs -> 125 MBs)
- Add instructions on how to run the Docker image pulled from Docker Hub
- Update README